### PR TITLE
feat: extend branch cleanup and repository updates to submodules

### DIFF
--- a/scripts/clean-local-branches.ts
+++ b/scripts/clean-local-branches.ts
@@ -1,23 +1,39 @@
 import {execSync} from 'node:child_process';
-import {fetchBranches, getCurrentBranchName, getLocalBranchesList} from './helpers/git';
+import {fetchBranches, getCurrentBranchName, getLocalBranchesList, getSubmodulePaths} from './helpers/git';
 import {colorize, ColorKeys} from './helpers/shell-colors';
 
 /**
- * @description Clean local git branches that have been removed from remote
+ * @description Clean local git branches that have been removed from remote, in the current repository and any submodules.
  */
-fetchBranches();
+const cleanGoneBranches = (label: string): void => {
+  console.log(colorize(`🔍 Cleaning ${label}`, ColorKeys.GREEN));
 
-const currentBranch = getCurrentBranchName();
+  fetchBranches();
 
-getLocalBranchesList(false)
-  .forEach(branchName => {
-    if (branchName === currentBranch) {
-      console.log(colorize('⚠️  Your current branch has gone. Switch to another branch to remove it', ColorKeys.YELLOW));
-    }
-    else {
-      console.log(execSync(`git branch -d -f ${branchName}`).toString());
-    }
-  });
+  const currentBranch = getCurrentBranchName();
+
+  getLocalBranchesList(false)
+    .forEach(branchName => {
+      if (branchName === currentBranch) {
+        console.log(colorize('⚠️  Your current branch has gone. Switch to another branch to remove it', ColorKeys.YELLOW));
+      }
+      else {
+        console.log(execSync(`git branch -d -f ${branchName}`).toString());
+      }
+    });
+};
+
+const rootRepository = process.cwd();
+
+cleanGoneBranches('main repository');
+
+const submodulePaths = getSubmodulePaths();
+for (const submodulePath of submodulePaths) {
+  process.chdir(submodulePath);
+  cleanGoneBranches(`submodule ${submodulePath}`);
+}
+
+process.chdir(rootRepository);
 
 console.log(colorize('🎉 Finished, everything is clean', ColorKeys.GREEN));
 

--- a/scripts/egerie/update-repositories.ts
+++ b/scripts/egerie/update-repositories.ts
@@ -8,6 +8,7 @@ import {
   getUncommittedFilesList,
   rebaseLocaleBranch,
   switchLocalBranch,
+  updateSubmodules,
 } from '../helpers/git';
 import {colorize, ColorKeys} from '../helpers/shell-colors';
 
@@ -35,37 +36,64 @@ const getSubRepoList = (currentPath: string) => {
 getSubRepoList(baseRepositoryPath);
 getSubRepoList(workspacePath);
 
-for (const repository of repositoriesList) {
+const errors: {message: string; repository: string}[] = [];
+
+const processRepository = async (repository: string): Promise<void> => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  console.info(`${colorize('Processing', ColorKeys.GREEN)} ${colorize(repository.split('/').at(-1)!, ColorKeys.YELLOW)}`);
+  const repositoryName = repository.split('/').at(-1)!;
+  console.info(`${colorize('Processing', ColorKeys.GREEN)} ${colorize(repositoryName, ColorKeys.YELLOW)}`);
 
   process.chdir(repository);
 
-  fetchBranches();
+  try {
+    fetchBranches();
 
-  // Check if there are uncommitted files
-  if (getUncommittedFilesList().length) {
-    console.error('❗ Your branch has uncommitted files. This repository has been fetched, but branch will not be rebased');
-    break;
-  }
+    // Check if there are uncommitted files
+    if (getUncommittedFilesList().length) {
+      const message = 'Your branch has uncommitted files. This repository has been fetched, but branch will not be rebased';
+      console.error(`❗ ${message}`);
+      errors.push({message, repository: repositoryName});
+      return;
+    }
 
-  const currentBranch = getCurrentBranchName();
+    const currentBranch = getCurrentBranchName();
 
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const mainBranchName = getLocalBranchesList().find(branchName => ['main', 'master'].includes(branchName))!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const mainBranchName = getLocalBranchesList().find(branchName => ['main', 'master'].includes(branchName))!;
 
-  if (currentBranch !== mainBranchName) {
-    const {willSwitch} = await prompts({
-      initial: true,
-      message: `${colorize('You are on the branch', ColorKeys.YELLOW)} ${colorize(currentBranch, ColorKeys.GREEN)}${colorize(', do you want to switch branch before?', ColorKeys.YELLOW)}`,
-      name: 'willSwitch',
-      type: 'confirm',
-    }) as {willSwitch: boolean};
+    if (currentBranch !== mainBranchName) {
+      const {willSwitch} = await prompts({
+        initial: true,
+        message: `${colorize('You are on the branch', ColorKeys.YELLOW)} ${colorize(currentBranch, ColorKeys.GREEN)}${colorize(', do you want to switch branch before?', ColorKeys.YELLOW)}`,
+        name: 'willSwitch',
+        type: 'confirm',
+      }) as {willSwitch: boolean};
 
-    if (willSwitch) {
-      switchLocalBranch(mainBranchName);
+      if (willSwitch) {
+        switchLocalBranch(mainBranchName);
+      }
+    }
+
+    rebaseLocaleBranch({branchName: currentBranch, willDisplayInformation: false});
+
+    if (existsSync(path.resolve(repository, '.gitmodules'))) {
+      updateSubmodules();
     }
   }
+  catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`❗ ${message}`);
+    errors.push({message, repository: repositoryName});
+  }
+};
 
-  rebaseLocaleBranch({branchName: currentBranch, willDisplayInformation: false});
+for (const repository of repositoriesList) {
+  await processRepository(repository);
+}
+
+if (errors.length) {
+  console.info(`\n${colorize('Errors encountered:', ColorKeys.RED)}`);
+  for (const {repository, message} of errors) {
+    console.info(`  ${colorize(repository, ColorKeys.YELLOW)}: ${message}`);
+  }
 }

--- a/scripts/helpers/git.ts
+++ b/scripts/helpers/git.ts
@@ -9,8 +9,7 @@ export const fetchBranches = (): void => {
     execSync('git fetch -p').toString();
   }
   catch {
-    console.log(colorize('❗️ Can\'t fetch remotes branches.', ColorKeys.RED));
-    process.exit(1);
+    throw new Error('Can\'t fetch remotes branches.');
   }
 };
 
@@ -23,8 +22,7 @@ export const getRemoteBranchesList = (): string[] => {
       .split('\n');
   }
   catch {
-    console.log(colorize('❗️ Can\'t list remotes branches.', ColorKeys.RED));
-    process.exit(1);
+    throw new Error('Can\'t list remotes branches.');
   }
 };
 
@@ -41,8 +39,7 @@ export const switchLocalBranch = (branchToSwitch: string): void => {
     execSync(`git switch ${branchToSwitch}`);
   }
   catch {
-    console.info(colorize(`❗️ Can't switch to branch ${branchToSwitch}, maybe you should stash your work first`, ColorKeys.RED));
-    process.exit(1);
+    throw new Error(`Can't switch to branch ${branchToSwitch}, maybe you should stash your work first`);
   }
 };
 
@@ -57,8 +54,7 @@ export const getLocalBranchesList = (willKeepAllBranches = true): string[] => {
       .filter(branchName => !!branchName);
   }
   catch {
-    console.log(colorize('❗️ Can\'t get locale branches', ColorKeys.RED));
-    process.exit(1);
+    throw new Error('Can\'t get locale branches');
   }
 };
 
@@ -67,8 +63,7 @@ export const getCurrentBranchName = (): string => {
     return execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
   }
   catch {
-    console.log(colorize('❗️ Can\'t get current branch.', ColorKeys.RED));
-    process.exit(1);
+    throw new Error('Can\'t get current branch.');
   }
 };
 
@@ -84,6 +79,28 @@ export const getTagsList = (): string[] => {
 
 export const createAndPushTag = (tagName: string): void => {
   execSync(`git tag ${tagName} && git push origin ${tagName}`).toString();
+};
+
+export const updateSubmodules = (): void => {
+  try {
+    execSync('git submodule update --init --recursive').toString();
+  }
+  catch {
+    throw new Error('Can\'t update submodules.');
+  }
+};
+
+export const getSubmodulePaths = (): string[] => {
+  try {
+    const output = execSync('git submodule foreach --recursive --quiet pwd').toString().trim();
+    if (!output) {
+      return [];
+    }
+    return output.split('\n').map(line => line.trim()).filter(Boolean);
+  }
+  catch {
+    return [];
+  }
 };
 
 export const rebaseLocaleBranch = ({branchName, willDisplayInformation = true}: {branchName: string; willDisplayInformation?: boolean}): void => {


### PR DESCRIPTION
Clean gone branches inside submodules in addition to the main repository, update submodules after rebasing, and replace `process.exit` calls in git helpers with thrown errors so failures on one repository no longer abort the whole batch — they are now collected and reported at the end.